### PR TITLE
Allow visualization of points and frames

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ LoopThrottle 0.0.1
 MechanismGeometries 0.0.1
 MeshCat 0.0.2
 RigidBodyDynamics 0.4
+GeometryTypes

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,5 @@ LoopThrottle 0.0.1
 MechanismGeometries 0.0.1
 MeshCat 0.0.2
 RigidBodyDynamics 0.4
-GeometryTypes
+GeometryTypes 0.4
+DocStringExtensions 0.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,4 +7,3 @@ MechanismGeometries 0.0.1
 MeshCat 0.0.2
 RigidBodyDynamics 0.4
 GeometryTypes 0.4
-DocStringExtensions 0.4

--- a/mechanism-demo.ipynb
+++ b/mechanism-demo.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Visualizing Frames\n",
+    "### Visualizing Frames and Points\n",
     "\n",
     "You can use the lower-level `setelement!()` function to attach geometries to frames in the mechanism. For example, to visualize a coordinate frame with a triad, you can do: "
    ]
@@ -64,14 +64,32 @@
    "source": [
     "lower_arm = bodies(robot)[end]\n",
     "body_frame = default_frame(lower_arm)\n",
-    "setelement!(mvis, body_frame, Triad(0.5))"
+    "setelement!(mvis, body_frame)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The triad is included in the MeshCat scene tree, so it will move along with the body to which it's attached: "
+    "And likewise, to visualize a point attached to a frame, you can do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radius = 0.05\n",
+    "name = \"my_point\"\n",
+    "setelement!(mvis, Point3D(body_frame, 0.2, 0.2, 0.2), radius, name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The triad and point are included in the MeshCat scene tree, so each will move along with the body to which it's attached:"
    ]
   },
   {

--- a/mechanism-demo.ipynb
+++ b/mechanism-demo.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "vis = Visualizer()\n",
     "# open(vis)  # open the visualizer in a separate tab/window\n",
-    "IJuliaCell(vis)"
+    "IJuliaCell(vis) # render the visualizer here inside the jupyter notebook"
    ]
   },
   {
@@ -44,6 +44,42 @@
     "state = MechanismState(robot, randn(2), randn(2))\n",
     "t, q, v = simulate(state, 5.0);\n",
     "\n",
+    "animate(mvis, t, q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualizing Frames\n",
+    "\n",
+    "You can use the lower-level `setelement!()` function to attach geometries to frames in the mechanism. For example, to visualize a coordinate frame with a triad, you can do: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lower_arm = bodies(robot)[end]\n",
+    "body_frame = default_frame(lower_arm)\n",
+    "setelement!(mvis, body_frame, Triad(0.5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The triad is included in the MeshCat scene tree, so it will move along with the body to which it's attached: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "animate(mvis, t, q)"
    ]
   },

--- a/src/MeshCatMechanisms.jl
+++ b/src/MeshCatMechanisms.jl
@@ -18,7 +18,8 @@ export VisualElement,
        visual_elements
 
 # Re-export from RigidBodyDynamics.jl
-export set_configuration!
+export set_configuration!,
+       Point3D
 
 using MeshCat
 using MeshCat: AbstractMaterial, AbstractObject, GeometryLike, Object
@@ -29,6 +30,7 @@ using RigidBodyDynamics.Graphs: ancestors, edge_to_parent, source, vertices, roo
 using Interpolations: interpolate, Gridded, Linear
 using LoopThrottle: @throttle
 using MechanismGeometries: visual_elements, VisualElement, Skeleton, URDFVisuals, AbstractGeometrySource
+using GeometryTypes: HyperSphere, Point
 
 include("visualizer.jl")
 include("animate.jl")

--- a/src/MeshCatMechanisms.jl
+++ b/src/MeshCatMechanisms.jl
@@ -31,6 +31,7 @@ using Interpolations: interpolate, Gridded, Linear
 using LoopThrottle: @throttle
 using MechanismGeometries: visual_elements, VisualElement, Skeleton, URDFVisuals, AbstractGeometrySource
 using GeometryTypes: HyperSphere, Point
+using DocStringExtensions
 
 include("visualizer.jl")
 include("animate.jl")

--- a/src/MeshCatMechanisms.jl
+++ b/src/MeshCatMechanisms.jl
@@ -31,7 +31,6 @@ using Interpolations: interpolate, Gridded, Linear
 using LoopThrottle: @throttle
 using MechanismGeometries: visual_elements, VisualElement, Skeleton, URDFVisuals, AbstractGeometrySource
 using GeometryTypes: HyperSphere, Point
-using DocStringExtensions
 
 include("visualizer.jl")
 include("animate.jl")

--- a/src/MeshCatMechanisms.jl
+++ b/src/MeshCatMechanisms.jl
@@ -5,17 +5,27 @@ module MeshCatMechanisms
 export MechanismVisualizer,
        animate,
        MeshCatSink,
+       setelement!
+
+# Re-export from MeshCat.jl
+export IJuliaCell,
+       Triad
+
+# Re-export from MechanismGeometries.jl
+export VisualElement,
        Skeleton,
        URDFVisuals,
-       visual_elements,
-       set_configuration!,
-       IJuliaCell
+       visual_elements
+
+# Re-export from RigidBodyDynamics.jl
+export set_configuration!
 
 using MeshCat
-using MeshCat: AbstractMaterial, AbstractObject
+using MeshCat: AbstractMaterial, AbstractObject, GeometryLike, Object
 using CoordinateTransformations
 using RigidBodyDynamics
 const rbd = RigidBodyDynamics
+using RigidBodyDynamics.Graphs: ancestors, edge_to_parent, source, vertices, root
 using Interpolations: interpolate, Gridded, Linear
 using LoopThrottle: @throttle
 using MechanismGeometries: visual_elements, VisualElement, Skeleton, URDFVisuals, AbstractGeometrySource

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -42,10 +42,9 @@ function Base.getindex(mvis::MechanismVisualizer, body::RigidBody)
 end
 
 """
+    setelement!(mvis::MechanismVisualizer, element::VisualElement, name::AbstractString="<element>")
+
 Attach the given visual element to the visualizer.
-
-$(SIGNATURES)
-
 The element's frame will determine how its geometry is attached to the scene
 tree, so that any other geometries attached to the same body will all move together.
 """
@@ -55,9 +54,9 @@ function setelement!(mvis::MechanismVisualizer, element::VisualElement, name::Ab
 end
 
 """
-Attach the given geometric object (geometry + material) to the visualizer at the given frame
+    setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, object::AbstractObject, name::AbstractString="<element>")
 
-$(SIGNATURES)
+Attach the given geometric object (geometry + material) to the visualizer at the given frame
 """
 function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, object::AbstractObject, name::AbstractString="<element>")
     body = rbd.body_fixed_frame_to_body(mechanism(mvis), frame)
@@ -68,33 +67,33 @@ function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, object:
 end
 
 """
-Attach the given geometry to the visualizer at the given frame, using its default material
+    setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, name::AbstractString="<element>")
 
-$(SIGNATURES)
+Attach the given geometry to the visualizer at the given frame, using its default material.
 """
-setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, args...) = setelement!(mvis, frame, Object(geometry), args...)
+setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, name::AbstractString="<element>") = setelement!(mvis, frame, Object(geometry), name)
 
 """
+    setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, material::AbstractMaterial, name::AbstractString="<element>")
+
 Construct an object with the given geometry and material and attach it to the visualizer
-
-$(SIGNATURES)
 """
-setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, material::AbstractMaterial, args...) = setelement!(mvis, frame, Object(geometry, material), args...)
+setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, material::AbstractMaterial, name::AbstractString="<element>") = setelement!(mvis, frame, Object(geometry, material), name)
 
 # Special cases for visualizing frames and points
 """
+    setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, scale::Real=0.5, name::AbstractString="<element>")
+
 Add a Triad geometry with the given scale to the visualizer at the specified frame
-
-$(SIGNATURES)
 """
-setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, scale::Real=0.5, args...) = setelement!(mvis, frame, Triad(scale), args...)
+setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, scale::Real=0.5, name::AbstractString="<element>") = setelement!(mvis, frame, Triad(scale), name)
 
 """
+    setelement!(mvis::MechanismVisualizer, point::Point3D, radius::Real=0.05, name::AbstractString="<element>")
+
 Add a HyperSphere geometry with the given radius to the visualizer at the given point
-
-$(SIGNATURES)
 """
-setelement!(mvis::MechanismVisualizer, point::Point3D, radius::Real=0.05, args...) = setelement!(mvis, point.frame, HyperSphere(Point(point.v[1], point.v[2], point.v[3]), convert(eltype(point.v), radius)), args...)
+setelement!(mvis::MechanismVisualizer, point::Point3D, radius::Real=0.05, name::AbstractString="<element>") = setelement!(mvis, point.frame, HyperSphere(Point(point.v[1], point.v[2], point.v[3]), convert(eltype(point.v), radius)), name)
 
 function _path(mechanism, body)
     body_ancestors = ancestors(body, mechanism.tree)
@@ -121,9 +120,18 @@ function _render_state!(mvis::MechanismVisualizer, state::MechanismState=mvis.st
 end
 
 """
-Set the configuration of the mechanism visualizer and re-render it
+    set_configuration!(mvis::MechanismVisualizer, args...)
 
-$(SIGNATURES)
+Set the configuration of the mechanism visualizer and re-render it.
+
+# Examples
+```julia-repl
+julia> set_configuration!(vis, [1., 2., 3.])
+```
+
+```julia-repl
+julia> set_configuration!(vis, findjoint(robot, "shoulder"), 1.0)
+```
 """
 function rbd.set_configuration!(mvis::MechanismVisualizer, args...)
     set_configuration!(mvis.state, args...)

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -68,17 +68,15 @@ function _render_state!(mvis::MechanismVisualizer, state::MechanismState=mvis.st
     if rbd.modcount(state.mechanism) != mvis.modcount
         error("Mechanism has been modified after creating the visualizer. Please create a new MechanismVisualizer")
     end
-    mechanism = mvis.state.mechanism
     vis = mvis.visualizer
-    tree = mechanism.tree # TODO: tree accessor?
+    tree = mechanism(mvis).tree # TODO: tree accessor?
     for body in vertices(tree)
         if body == root(tree)
             settransform!(vis, to_affine_map(transform_to_root(state, body)))
         else
-            path = _path(mechanism, body)
-            parent = source(edge_to_parent(body, mechanism.tree), mechanism.tree)
+            parent = source(edge_to_parent(body, tree), tree)
             tform = relative_transform(state, default_frame(body), default_frame(parent))
-            settransform!(vis[path...], to_affine_map(tform))
+            settransform!(mvis[body], to_affine_map(tform))
         end
     end
 end

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -57,6 +57,10 @@ end
 setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, args...) = setelement!(mvis, frame, Object(geometry), args...)
 setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, material::AbstractMaterial, args...) = setelement!(mvis, frame, Object(geometry, material), args...)
 
+# Special cases for visualizing frames and points
+setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, scale::Real=0.5, args...) = setelement!(mvis, frame, Triad(scale), args...)
+setelement!(mvis::MechanismVisualizer, point::Point3D, radius::Real=0.05, args...) = setelement!(mvis, point.frame, HyperSphere(Point(point.v[1], point.v[2], point.v[3]), convert(eltype(point.v), radius)), args...)
+
 function _path(mechanism, body)
     body_ancestors = ancestors(body, mechanism.tree)
     path = string.(reverse(body_ancestors))

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -16,29 +16,52 @@ end
 
 MechanismVisualizer(m::Mechanism, args...) = MechanismVisualizer(MechanismState{Float64}(m), args...)
 
+mechanism(mvis::MechanismVisualizer) = mvis.state.mechanism
+
 to_affine_map(tform::Transform3D) = AffineMap(rotation(tform), translation(tform))
 
 function _set_mechanism!(mvis::MechanismVisualizer, elements::AbstractVector{<:VisualElement})
     for (i, element) in enumerate(elements)
-        _set_element!(mvis, element, "geometry_$i")
+        setelement!(mvis, element, "geometry_$i")
     end
 end
 
-function _set_element!(mvis::MechanismVisualizer, element::VisualElement, name::AbstractString)
-    mechanism = mvis.state.mechanism
-    vis = mvis.visualizer
-    tree = mechanism.tree
-    # TODO: much of this information can be cached if this
-    # method becomes a performance bottleneck
-    body = rbd.body_fixed_frame_to_body(mechanism, element.frame)
-    body_ancestors = rbd.Graphs.ancestors(body, tree)
-    path = vcat(string.(reverse(body_ancestors)), string(element.frame))
-    frame_vis = vis[path...]
-    definition = rbd.frame_definition(body, element.frame)
-    settransform!(frame_vis, to_affine_map(definition))
-    setobject!(frame_vis[name], element.geometry, MeshLambertMaterial(color=element.color))
-    settransform!(frame_vis[name], element.transform)
+Base.getindex(mvis::MechanismVisualizer, x...) = getindex(mvis.visualizer, x...)
+
+# TODO: much of this information can be cached if this
+# method becomes a performance bottleneck.
+# We can probably just put `@memoize` from Memoize.jl right here.
+function Base.getindex(mvis::MechanismVisualizer, frame::CartesianFrame3D)
+    body = rbd.body_fixed_frame_to_body(mechanism(mvis), frame)
+    mvis[body][string(frame)]
 end
+
+function Base.getindex(mvis::MechanismVisualizer, body::RigidBody)
+    path = _path(mechanism(mvis), body)
+    mvis[path...]
+end
+
+function setelement!(mvis::MechanismVisualizer, element::VisualElement, name::AbstractString="<element>")
+    setelement!(mvis, element.frame, element.geometry, MeshLambertMaterial(color=element.color), name)
+    settransform!(mvis[element.frame][name], element.transform)
+end
+
+function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, object::AbstractObject, name::AbstractString="<element>")
+    body = rbd.body_fixed_frame_to_body(mechanism(mvis), frame)
+    definition = rbd.frame_definition(body, frame)
+    frame_vis = mvis[frame]
+    settransform!(frame_vis, to_affine_map(definition))
+    setobject!(frame_vis[name], object)
+end
+
+setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, args...) = setelement!(mvis, frame, Object(geometry), args...)
+setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, material::AbstractMaterial, args...) = setelement!(mvis, frame, Object(geometry, material), args...)
+
+function _path(mechanism, body)
+    body_ancestors = ancestors(body, mechanism.tree)
+    path = string.(reverse(body_ancestors))
+end
+
 
 function _render_state!(mvis::MechanismVisualizer, state::MechanismState=mvis.state)
     @assert mvis.state.mechanism === state.mechanism
@@ -48,14 +71,13 @@ function _render_state!(mvis::MechanismVisualizer, state::MechanismState=mvis.st
     mechanism = mvis.state.mechanism
     vis = mvis.visualizer
     tree = mechanism.tree # TODO: tree accessor?
-    for vertex in rbd.Graphs.vertices(tree)
-        body = vertex
-        if body == rbd.Graphs.root(tree)
+    for body in vertices(tree)
+        if body == root(tree)
             settransform!(vis, to_affine_map(transform_to_root(state, body)))
         else
-            body_ancestors = rbd.Graphs.ancestors(vertex, tree)
-            path = string.(reverse(body_ancestors))
-            tform = relative_transform(state, default_frame(body), default_frame(body_ancestors[2]))
+            path = _path(mechanism, body)
+            parent = source(edge_to_parent(body, mechanism.tree), mechanism.tree)
+            tform = relative_transform(state, default_frame(body), default_frame(parent))
             settransform!(vis[path...], to_affine_map(tform))
         end
     end

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -41,11 +41,24 @@ function Base.getindex(mvis::MechanismVisualizer, body::RigidBody)
     mvis[path...]
 end
 
+"""
+Attach the given visual element to the visualizer.
+
+$(SIGNATURES)
+
+The element's frame will determine how its geometry is attached to the scene
+tree, so that any other geometries attached to the same body will all move together.
+"""
 function setelement!(mvis::MechanismVisualizer, element::VisualElement, name::AbstractString="<element>")
     setelement!(mvis, element.frame, element.geometry, MeshLambertMaterial(color=element.color), name)
     settransform!(mvis[element.frame][name], element.transform)
 end
 
+"""
+Attach the given geometric object (geometry + material) to the visualizer at the given frame
+
+$(SIGNATURES)
+"""
 function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, object::AbstractObject, name::AbstractString="<element>")
     body = rbd.body_fixed_frame_to_body(mechanism(mvis), frame)
     definition = rbd.frame_definition(body, frame)
@@ -54,11 +67,33 @@ function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, object:
     setobject!(frame_vis[name], object)
 end
 
+"""
+Attach the given geometry to the visualizer at the given frame, using its default material
+
+$(SIGNATURES)
+"""
 setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, args...) = setelement!(mvis, frame, Object(geometry), args...)
+
+"""
+Construct an object with the given geometry and material and attach it to the visualizer
+
+$(SIGNATURES)
+"""
 setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::GeometryLike, material::AbstractMaterial, args...) = setelement!(mvis, frame, Object(geometry, material), args...)
 
 # Special cases for visualizing frames and points
+"""
+Add a Triad geometry with the given scale to the visualizer at the specified frame
+
+$(SIGNATURES)
+"""
 setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, scale::Real=0.5, args...) = setelement!(mvis, frame, Triad(scale), args...)
+
+"""
+Add a HyperSphere geometry with the given radius to the visualizer at the given point
+
+$(SIGNATURES)
+"""
 setelement!(mvis::MechanismVisualizer, point::Point3D, radius::Real=0.05, args...) = setelement!(mvis, point.frame, HyperSphere(Point(point.v[1], point.v[2], point.v[3]), convert(eltype(point.v), radius)), args...)
 
 function _path(mechanism, body)
@@ -85,6 +120,11 @@ function _render_state!(mvis::MechanismVisualizer, state::MechanismState=mvis.st
     end
 end
 
+"""
+Set the configuration of the mechanism visualizer and re-render it
+
+$(SIGNATURES)
+"""
 function rbd.set_configuration!(mvis::MechanismVisualizer, args...)
     set_configuration!(mvis.state, args...)
     _render_state!(mvis)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,9 @@ vis = Visualizer()
         @test configuration(mvis) == [1.0, -0.5]
         @test configuration(mvis, findjoint(robot, "shoulder")) == [1.0]
 
+        setelement!(mvis, default_frame(bodies(robot)[end]))
+        setelement!(mvis, Point3D(default_frame(bodies(robot)[3]), 0.2, 0.2, 0.2))
+
         @testset "simulation and animation" begin
             state = MechanismState(robot, randn(2), randn(2))
             t, q, v = simulate(state, 5.0);


### PR DESCRIPTION
New features: 

```
setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, scale::Real=0.5) # visualize a triad
setelement!(mvis::MechanismVisualizer, pt::Point3D, radius::Real=0.05) # visualize a point
setelement!(mvis::MechanismVisualiezr, frame::CartesianFrame3D, geometry) # visualize any geometry attached to a frame
```