### PR TITLE
Support the new MeshCat animation system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,8 @@ branches:
   only:
     - master
 
-addons:
-  apt:
-    packages:
-      - libzmq3
-
 before_script:
   - julia -e 'Pkg.init(); Pkg.add("MeshCat"); Pkg.checkout("MeshCat")'
-  - julia -e 'Pkg.checkout("WebIO")'
 
 after_success:
   # push coverage results to Codecov

--- a/mechanism-demo.ipynb
+++ b/mechanism-demo.ipynb
@@ -42,9 +42,44 @@
    "outputs": [],
    "source": [
     "state = MechanismState(robot, randn(2), randn(2))\n",
-    "t, q, v = simulate(state, 5.0);\n",
+    "t, q, v = simulate(state, 5.0);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Animating a Trajectory\n",
     "\n",
-    "animate(mvis, t, q)"
+    "You can animate a trajectory (a list of times and configurations) with the `setanimation!()` function. To create an animation and play it in the visualizer, you just need to do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "setanimation!(mvis, t, q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Replaying the Animation\n",
+    "\n",
+    "When you use `setanimation!`, the entire animation is sent to the visualizer, so you can replay it at will. In the viewer, click \"Open Controls\" in the top right corner, go to \"Animation\" -> \"default\" and click \"play\" to play the animation again. \n",
+    "\n",
+    "### Recording the Animation\n",
+    "\n",
+    "You can also record an animation directly from the MeshCat viewer. Just open the controls and go to \"Animation\" -> \"default\" -> \"Recording\" and click \"record\". The animation will play back (slowly, as it needs to cleanly capture every frame), and then you'll be able to download the resulting frames. \n",
+    "\n",
+    "Currently, MeshCat downloads an animation as a `.tar` file containing all of the individual frames. To convert that into a video, you just need to install the `ffmpeg` program (`apt-get install ffmpeg` on Ubuntu 18.04) and then run: \n",
+    "\n",
+    "```julia\n",
+    "MeshCat.convert_frames_to_video(\"/path/to/downloads/meshcat_xxx.tar\")\n",
+    "```"
    ]
   },
   {
@@ -98,7 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "animate(mvis, t, q)"
+    "setanimation!(mvis, t, q)"
    ]
   },
   {
@@ -168,7 +203,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.6.2",
+   "display_name": "Julia 0.6.3",
    "language": "julia",
    "name": "julia-0.6"
   },
@@ -176,7 +211,7 @@
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.6.2"
+   "version": "0.6.3"
   }
  },
  "nbformat": 4,

--- a/src/MeshCatMechanisms.jl
+++ b/src/MeshCatMechanisms.jl
@@ -9,7 +9,8 @@ export MechanismVisualizer,
 
 # Re-export from MeshCat.jl
 export IJuliaCell,
-       Triad
+       Triad,
+       setanimation!
 
 # Re-export from MechanismGeometries.jl
 export VisualElement,
@@ -22,7 +23,6 @@ export set_configuration!,
        Point3D
 
 using MeshCat
-using MeshCat: AbstractMaterial, AbstractObject, GeometryLike, Object
 using CoordinateTransformations
 using RigidBodyDynamics
 const rbd = RigidBodyDynamics

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -29,3 +29,38 @@ function animate(vis::MechanismVisualizer,
         t == tf && break
     end max_rate = fps
 end
+
+using MeshCat: AnimationClip, TransformTrack, Animation, SetAnimation, Path
+
+function setanimation(mvis::MechanismVisualizer,
+                      times::Vector{Float64},
+                      configurations::AbstractVector{<:AbstractVector{<:Real}},
+                      fps::Integer=30)
+    state = MechanismState(mechanism(mvis))
+    clips = Dict{Path, AnimationClip{TransformTrack}}()
+    tree = mechanism(mvis).tree
+    @assert indices(times) == indices(configurations)
+    interpolated_configurations = interpolate((times,), configurations, Gridded(Linear()))
+    num_frames = floor(Int, (times[end] - first(times)) * fps)
+    for frame in 0:num_frames
+        time = first(times) + frame / fps
+        set_configuration!(state, interpolated_configurations[time])
+        for body in vertices(tree)
+            if body === root(tree)
+                continue
+            end
+            parent = source(edge_to_parent(body, tree), tree)
+            tform = to_affine_map(relative_transform(state, default_frame(body), default_frame(parent)))
+            path = mvis[body].path
+            clip = get!(clips, path) do
+                AnimationClip{TransformTrack}(tracks=[TransformTrack([])], fps=fps)
+            end
+            track = first(clip.tracks)
+            push!(track.frames, frame => tform)
+        end
+    end
+    anim = Animation(collect(clips))
+    cmd = SetAnimation(anim, true, 1)
+    send(mvis.visualizer.core, cmd)
+    return cmd
+end

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -30,37 +30,24 @@ function animate(vis::MechanismVisualizer,
     end max_rate = fps
 end
 
-using MeshCat: AnimationClip, TransformTrack, Animation, SetAnimation, Path
-
-function setanimation(mvis::MechanismVisualizer,
+function MeshCat.setanimation!(mvis::MechanismVisualizer,
                       times::Vector{Float64},
-                      configurations::AbstractVector{<:AbstractVector{<:Real}},
-                      fps::Integer=30)
-    state = MechanismState(mechanism(mvis))
-    clips = Dict{Path, AnimationClip{TransformTrack}}()
-    tree = mechanism(mvis).tree
+                      configurations::AbstractVector{<:AbstractVector{<:Real}};
+                      fps::Integer=30,
+                      play::Bool=true,
+                      repetitions::Integer=1)
+    q0 = copy(configuration(state(mvis)))
     @assert indices(times) == indices(configurations)
     interpolated_configurations = interpolate((times,), configurations, Gridded(Linear()))
+    animation = Animation()
     num_frames = floor(Int, (times[end] - first(times)) * fps)
     for frame in 0:num_frames
         time = first(times) + frame / fps
-        set_configuration!(state, interpolated_configurations[time])
-        for body in vertices(tree)
-            if body === root(tree)
-                continue
-            end
-            parent = source(edge_to_parent(body, tree), tree)
-            tform = to_affine_map(relative_transform(state, default_frame(body), default_frame(parent)))
-            path = mvis[body].path
-            clip = get!(clips, path) do
-                AnimationClip{TransformTrack}(tracks=[TransformTrack([])], fps=fps)
-            end
-            track = first(clip.tracks)
-            push!(track.frames, frame => tform)
+        set_configuration!(state(mvis), interpolated_configurations[time])
+        atframe(animation, visualizer(mvis), frame) do frame_visualizer
+            _render_state!(MechanismVisualizer(state(mvis), frame_visualizer))
         end
     end
-    anim = Animation(collect(clips))
-    cmd = SetAnimation(anim, true, 1)
-    send(mvis.visualizer.core, cmd)
-    return cmd
+    setanimation!(visualizer(mvis), animation, play=play, repetitions=repetitions)
+    set_configuration!(state(mvis), q0)
 end

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -16,7 +16,6 @@ end
 
 function setelement!(vis::MechanismVisualizer, source::AbstractGeometrySource)
     elements = visual_elements(mechanism(vis), source)
-    @show elements
     _set_mechanism!(vis, elements)
     _render_state!(vis)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ vis = Visualizer()
             state = MechanismState(robot, randn(2), randn(2))
             t, q, v = simulate(state, 5.0);
             animate(mvis, t, q)
+            setanimation!(mvis, t, q)
         end
     end
 
@@ -45,6 +46,7 @@ vis = Visualizer()
             state = MechanismState(robot, randn(1), randn(1))
             t, q, v = simulate(state, 5.0);
             animate(mvis, t, q)
+            setanimation!(mvis, t, q)
         end
     end
 


### PR DESCRIPTION
This implements `setanimation!(vis::MechanismVisualizer, times, qs)`.

Previously, we had `animate(vis, times, qs)`, which would repeatedly draw to the visualizer in a Julia loop. That worked fine, but it made replaying or controlling animations harder. MeshCat now understands animations internally, so we can essentially send that vector of times and transforms to the visualizer as an entire object. This means that we can have play/pause/speed controls in the viewer, and the Julia process is free from having to handle loop timing, which is already well implemented by the Three.js animation system. 

cc @tkoolen I'll probably keep the older `animate()` function around, since it works just fine, but we might decide to get rid of it eventually, since `setanimation!()` should be a nicer experience all around. 

Requires: 
- [x] https://github.com/rdeits/meshcat/pull/22
- [x] https://github.com/rdeits/MeshCat.jl/pull/34
- [ ] New MeshCat.jl tag