### PR TITLE
Fix error when position bounds are negative.

### DIFF
--- a/src/manipulate.jl
+++ b/src/manipulate.jl
@@ -28,8 +28,9 @@ function sliders(joint::Joint, values=clamp.(zeros(num_positions(joint)), positi
                  resolution=0.01, prefix="")
     map(bounds, labels, values) do b, label, value
         num_steps = ceil(Int, (upper(b) - lower(b)) / resolution)
+        r = range(lower(b), stop=upper(b), length=num_steps)
         slider(range(lower(b), stop=upper(b), length=num_steps),
-               value=value,
+               value=clamp(value, first(r), last(r)),
                label=string(prefix, label))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,6 +104,14 @@ vis = Visualizer()
         widget = manipulate!(mvis)
     end
 
+    @testset "manipulation - negative bounds issue" begin
+        mechanism = rand_chain_mechanism(Float64, Revolute{Float64})
+        joint = first(joints(mechanism))
+        joint.position_bounds .= RigidBodyDynamics.Bounds(-2.0, -1.0)
+        mvis = MechanismVisualizer(mechanism)
+        widget = manipulate!(mvis)
+    end
+
     @testset "examples" begin
         dir = joinpath(@__DIR__, "..", "examples")
         for file in readdir(dir)


### PR DESCRIPTION
Before this change, the test I added resulted in:

```julia
BoundsError: attempt to access 100-element Array{String,1} at index [101]

Stacktrace:
 [1] getindex(::Array{String,1}, ::Int64) at ./array.jl:731
 [2] #slider#75(::String, ::String, ::Observables.Observable{Any}, ::Base.Iterators.Pairs{Symbol,String,Tuple{Symbol},NamedTuple{(:label,),Tuple{String}}}, ::Function, ::InteractBase.NativeHTML, ::Base.OneTo{Int64}, ::Array{String,1}) at /home/twan/.julia/dev/InteractBase/src/slider.jl:68
 [3] (::getfield(InteractBase, Symbol("#kw##slider")))(::NamedTuple{(:value, :label),Tuple{Observables.Observable{Any},String}}, ::typeof(InteractBase.slider), ::InteractBase.NativeHTML, ::Base.OneTo{Int64}, ::Array{String,1}) at ./none:0
 [4] #slider#67(::Float64, ::Base.Iterators.Pairs{Symbol,String,Tuple{Symbol},NamedTuple{(:label,),Tuple{String}}}, ::Function, ::InteractBase.NativeHTML, ::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}, ::Array{String,1}) at /home/twan/.julia/dev/InteractBase/src/slider.jl:24
 [5] #slider at ./none:0 [inlined] (repeats 2 times)
 [6] #slider#170(::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:value, :label),Tuple{Float64,String}}}, ::Function, ::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}) at /home/twan/.julia/dev/InteractBase/src/defaults.jl:12
 [7] #slider at ./none:0 [inlined]
 [8] (::getfield(MeshCatMechanisms.Manipulate, Symbol("##38#39")){Float64,String})(::RigidBodyDynamics.Bounds{Float64}, ::String, ::Float64) at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:31
 [9] iterate at ./generator.jl:36 [inlined]
 [10] collect(::Base.Generator{Base.Iterators.Zip{Array{RigidBodyDynamics.Bounds{Float64},1},Base.Iterators.Zip2{Array{String,1},SubArray{Float64,1,Array{Float64,1},Tuple{UnitRange{Int64}},true}}},getfield(Base, Symbol("##3#4")){getfield(MeshCatMechanisms.Manipulate, Symbol("##38#39")){Float64,String}}}) at ./array.jl:619
 [11] map at ./abstractarray.jl:2060 [inlined]
 [12] #sliders#37 at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:29 [inlined]
 [13] #sliders at ./none:0 [inlined]
 [14] #widget#22(::String, ::Function, ::Joint{Float64,Revolute{Float64}}, ::SubArray{Float64,1,Array{Float64,1},Tuple{UnitRange{Int64}},true}) at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:50
 [15] widget(::Joint{Float64,Revolute{Float64}}, ::SubArray{Float64,1,Array{Float64,1},Tuple{UnitRange{Int64}},true}) at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:50
 [16] _broadcast_getindex_evalf at ./broadcast.jl:574 [inlined]
 [17] _broadcast_getindex at ./broadcast.jl:547 [inlined]
 [18] getindex at ./broadcast.jl:507 [inlined]
 [19] macro expansion at ./broadcast.jl:814 [inlined]
 [20] macro expansion at ./simdloop.jl:73 [inlined]
 [21] copyto! at ./broadcast.jl:813 [inlined]
 [22] copyto! at ./broadcast.jl:768 [inlined]
 [23] copy at ./broadcast.jl:744 [inlined]
 [24] materialize at ./broadcast.jl:724 [inlined]
 [25] manipulate!(::getfield(MeshCatMechanisms.Manipulate, Symbol("##15#16")){getfield(MeshCatMechanisms.Manipulate, Symbol("##17#18")),MechanismVisualizer{MechanismState{Float64,Float64,Float64,TypeSortedCollections.TypeSortedCollection{Tuple{Array{Joint{Float64,Revolute{Float64}},1}},1}},MeshCat.Visualizer}}, ::MechanismState{Float64,Float64,Float64,TypeSortedCollections.TypeSortedCollection{Tuple{Array{Joint{Float64,Revolute{Float64}},1}},1}}) at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:60
 [26] manipulate! at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:76 [inlined]
 [27] manipulate!(::MechanismVisualizer{MechanismState{Float64,Float64,Float64,TypeSortedCollections.TypeSortedCollection{Tuple{Array{Joint{Float64,Revolute{Float64}},1}},1}},MeshCat.Visualizer}) at /home/twan/.julia/dev/MeshCatMechanisms/src/manipulate.jl:82
 [28] top-level scope at In[23]:5
```
