### PR TITLE
Require the latest MeshCat and MechanismGeometries

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,6 +6,6 @@ GeometryTypes 0.4
 Interpolations 0.9
 InteractBase 0.8
 LoopThrottle 0.0.1
-MechanismGeometries 0.1.2
-MeshCat 0.2.1
+MechanismGeometries 0.2
+MeshCat 0.6
 RigidBodyDynamics 0.4


### PR DESCRIPTION
Waiting on: https://github.com/rdeits/MeshCat.jl/pull/81 and https://github.com/JuliaRobotics/MechanismGeometries.jl/pull/10

Along with https://github.com/JuliaLang/METADATA.jl/pull/20178 this should ensure that users always have compatible versions of MeshCat and MechanismGeometries