### PR TITLE
Deprecate `setanimation!(mvis, t, q)` in favor of `setanimation!(mvis, animation)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MeshCatMechanisms"
 uuid = "6ad125db-dd91-5488-b820-c1df6aab299d"
-version = "0.6.0"
+version = "0.7.0"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "## Animating a Trajectory\n",
     "\n",
-    "You can animate a trajectory (a list of times and configurations) with the `setanimation!()` function. To create an animation and play it in the visualizer, you just need to do:"
+    "You can animate a trajectory (a list of times and configurations) by creating an `Animation` and calling `setanimation!` to pass it to the visuailzer:"
    ]
   },
   {
@@ -60,7 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "setanimation!(mvis, t, q)"
+    "animation = Animation(mvis, t, q)\n",
+    "setanimation!(mvis, animation)"
    ]
   },
   {
@@ -124,16 +125,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The triad and point are included in the MeshCat scene tree, so each will move along with the body to which it's attached:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "setanimation!(mvis, t, q)"
+    "The triad and point are included in the MeshCat scene tree, so each will move along with the body to which it's attached. \n",
+    "\n",
+    "\n",
+    "Try clicking \"Animation\" -> \"default\" -> \"play\" again in the MeshCat window. You should see the arm animation repeat, and the point and triad you've added will move as well. "
    ]
   },
   {
@@ -206,16 +201,20 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": "3bd05bbcc8404a329198a25d86e23539",
+   "lastKernelId": "cc89f867-0754-4f63-b35b-9e38ff54bdd4"
+  },
   "kernelspec": {
-   "display_name": "Julia 0.6.4",
+   "display_name": "Julia 1.3.1",
    "language": "julia",
-   "name": "julia-0.6"
+   "name": "julia-1.3"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.6.4"
+   "version": "1.3.1"
   }
  },
  "nbformat": 4,

--- a/examples/interactive_manipulation.ipynb
+++ b/examples/interactive_manipulation.ipynb
@@ -131,16 +131,20 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": null,
+   "lastKernelId": null
+  },
   "kernelspec": {
-   "display_name": "Julia 0.7.0",
+   "display_name": "Julia 1.3.1",
    "language": "julia",
-   "name": "julia-0.7"
+   "name": "julia-1.3"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.7.0"
+   "version": "1.3.1"
   }
  },
  "nbformat": 4,

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -49,14 +49,31 @@ function MeshCat.Animation(mvis::MechanismVisualizer,
     return animation
 end
 
+MeshCat.setanimation!(mvis::MechanismVisualizer, args...; kw...) =
+    setanimation!(visualizer(mvis), args...; kw...)
+
 function MeshCat.setanimation!(mvis::MechanismVisualizer,
                       times::AbstractVector{<:Real},
                       configurations::AbstractVector{<:AbstractVector{<:Real}};
                       fps::Integer=30,
                       play::Bool=true,
                       repetitions::Integer=1)
-    q0 = copy(configuration(state(mvis)))
-    animation = Animation(mvis, times, configurations; fps=fps)
-    setanimation!(visualizer(mvis), animation, play=play, repetitions=repetitions)
-    set_configuration!(state(mvis), q0)
+    Base.depwarn("""
+    `setanimation!(mvis, times, configurations; ..)` is deprecated. Instead, you can construct an `Animation` and then call `setanimation!` with the result.
+
+    For examle, if you previously did:
+
+    ```
+    setanimation!(mvis, times, configurations, fps=30, play=true)
+    ```
+
+    You should now do:
+
+    ```
+    animation = Animation(mvis, times, configurations, fps=25)
+    setanimation!(mvis, animation, play=true)
+    ```
+    """, :setanimation_t_q)
+    animation = Animation(mvis, times, configurations, fps=fps)
+    setanimation!(mvis, animation, play=play, repetitions=repetitions)
 end

--- a/src/animate.jl
+++ b/src/animate.jl
@@ -61,7 +61,7 @@ function MeshCat.setanimation!(mvis::MechanismVisualizer,
     Base.depwarn("""
     `setanimation!(mvis, times, configurations; ..)` is deprecated. Instead, you can construct an `Animation` and then call `setanimation!` with the result.
 
-    For examle, if you previously did:
+    For example, if you previously did:
 
     ```
     setanimation!(mvis, times, configurations, fps=30, play=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,14 @@ vis = Visualizer()
             state = MechanismState(robot, randn(2), randn(2))
             t, q, v = simulate(state, 5.0);
             animate(mvis, t, q)
+            animation = Animation(mvis, t, q)
+            setanimation!(mvis, animation)
+        end
+
+        @testset "deprecated `setanimation!`" begin
+            state = MechanismState(robot, randn(2), randn(2))
+            t, q, v = simulate(state, 5.0);
+            animate(mvis, t, q)
             setanimation!(mvis, t, q)
         end
     end
@@ -48,7 +56,7 @@ vis = Visualizer()
             state = MechanismState(robot, randn(1), randn(1))
             t, q, v = simulate(state, 5.0);
             animate(mvis, t, q)
-            setanimation!(mvis, t, q)
+            setanimation!(mvis, Animation(mvis, t, q))
         end
     end
 


### PR DESCRIPTION
Per suggestion from https://github.com/JuliaRobotics/MeshCatMechanisms.jl/pull/34#issue-296378970