### PR TITLE
Use MeshFileObject for DAE files

### DIFF
--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -99,7 +99,7 @@ function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometr
     # All other meshes are loaded as MeshFileGeometry which uses MeshIO
     # to load the mesh geometry in Julia (but does not currently handle
     # any materials or textures).
-    if ext in (".obj", ".dae")
+    if ext == ".dae"
         obj = MeshFileObject(geometry.filename)
     else
         obj = Object(MeshFileGeometry(geometry.filename), material)

--- a/src/visualizer.jl
+++ b/src/visualizer.jl
@@ -92,8 +92,19 @@ function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometr
     setelement!(mvis, frame, Object(geometry, material), name)
 end
 
-function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::MeshFile, args...)
-    setelement!(mvis, frame, MeshFileGeometry(geometry.filename), args...)
+function setelement!(mvis::MechanismVisualizer, frame::CartesianFrame3D, geometry::MeshFile, material::AbstractMaterial, name::AbstractString="<element>")
+    ext = lowercase(splitext(geometry.filename)[2])
+    # We load .obj and .dae files as MeshFileObject so that threejs can
+    # handle loading their built-in primitives, materials, and textures.
+    # All other meshes are loaded as MeshFileGeometry which uses MeshIO
+    # to load the mesh geometry in Julia (but does not currently handle
+    # any materials or textures).
+    if ext in (".obj", ".dae")
+        obj = MeshFileObject(geometry.filename)
+    else
+        obj = Object(MeshFileGeometry(geometry.filename), material)
+    end
+    setelement!(mvis, frame, obj, name)
 end
 
 # Special cases for visualizing frames and points


### PR DESCRIPTION
This code was copied from the rd/mesh-file-object branch to allow visualization of the materials of DAE files. According to the commit on that branch, it didn't work on the Valkyrie meshes at the time, but it now works beautifully on the Franka Panda arm:

![image](https://user-images.githubusercontent.com/19652890/103722236-5d07c600-4f84-11eb-810b-054b26189018.png)

This is using the panda_arm_hand urdf at https://github.com/frankaemika/franka_ros/tree/kinetic-devel/franka_description/robots.
